### PR TITLE
Upgrade Django revision 01

### DIFF
--- a/cicd/microservice.tf
+++ b/cicd/microservice.tf
@@ -20,7 +20,7 @@ module "appl_tracky_api" {
   app_label               = "appl-tracky-api"
   app_exposed_port        = 8001
   app_deployed_domain     = "appl-tracky.api.shaungc.com"
-  cors_domain_whitelist   = ["rivernews.github.io", "appl-tracky.shaungc.com"]
+  cors_domain_whitelist   = ["https://rivernews.github.io", "https://appl-tracky.shaungc.com"]
   app_container_image     = "shaungc/appl-tracky-api"
   app_container_image_tag = var.app_container_image_tag
 


### PR DESCRIPTION
Continues #35, which causes prod server down due to CORS new requirement on origin:

```
SystemCheckError: System check identified some issues:
ERRORS:
?: (corsheaders.E013) Origin 'appl-tracky.shaungc.com' in CORS_ORIGIN_WHITELIST is missing scheme or netloc
	HINT: Add a scheme (e.g. https://) or netloc (e.g. example.com).
?: (corsheaders.E013) Origin 'rivernews.github.io' in CORS_ORIGIN_WHITELIST is missing scheme or netloc
	HINT: Add a scheme (e.g. https://) or netloc (e.g. example.com).
```

Works on issue https://github.com/rivernews/appl-tracky-api/issues/26.