### PR TITLE
Upgrade Django - fix 500 error missing trailing comma for tuple

### DIFF
--- a/django/django_server/settings.py
+++ b/django/django_server/settings.py
@@ -281,7 +281,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.BasicAuthentication',
     ) if DEBUG else (
-        'rest_framework_simplejwt.authentication.JWTAuthentication'
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
     ),
 }
 


### PR DESCRIPTION
Continue: #35 , #36.
Working on: #26 .